### PR TITLE
text centered on the 404 page

### DIFF
--- a/src/app/page-not-found/page-not-found.component.scss
+++ b/src/app/page-not-found/page-not-found.component.scss
@@ -26,6 +26,7 @@ p {
   font-family: "Fira Code", monospace;
   font-size: 1.5rem;
   color: #fff;
+  text-align: center;
 }
 
 


### PR DESCRIPTION
This pull request includes a small change to the `src/app/page-not-found/page-not-found.component.scss` file. The change centers the text in the page-not-found component.

Changes in styling:

* [`src/app/page-not-found/page-not-found.component.scss`](diffhunk://#diff-b47d120356e1eb0c2420351f78112f89ce05c197a589b70c265f686b719c74deR29): Added `text-align: center;` to the `p` tag to center the text.