### PR TITLE
Fix fontsize was too big

### DIFF
--- a/src/app/projecs/projecs.component.scss
+++ b/src/app/projecs/projecs.component.scss
@@ -180,7 +180,7 @@ span {
   margin: 0;
   > h2 {
     margin: 0;
-    font-size: 64px;
+    font-size: 55px;
   }
   h1 {
     font-family: "Fira Code", sans-serif;


### PR DESCRIPTION
This pull request includes a small change to the `src/app/projecs/projecs.component.scss` file. The change adjusts the font size of the `h2` element within a `span` tag.

* [`src/app/projecs/projecs.component.scss`](diffhunk://#diff-071dde2f703ed6c09f541ba9771aef99884d9fe1a302b69ae1c8bbfb82abc5cbL183-R183): Changed the `font-size` of `h2` from `64px` to `55px`.